### PR TITLE
feat: #16 WebRTC를 이용한 화상채팅 기능

### DIFF
--- a/src/public/js/components/Video.js
+++ b/src/public/js/components/Video.js
@@ -6,8 +6,8 @@ const defaultState = {
   muted: false,
   width: 100,
   height: 100,
-  src: "",
-  srcObject: {},
+  src: null,
+  srcObject: null,
 };
 
 class Video extends Component {

--- a/src/public/js/components/VideoList.js
+++ b/src/public/js/components/VideoList.js
@@ -1,0 +1,35 @@
+import Component from "../Component.template.js";
+
+const defaultState = { videos: [] };
+
+class VideoList extends Component {
+  constructor({ $target, initialState }) {
+    super({ $target, initialState: { ...defaultState, ...initialState } });
+
+    this.node = document.createElement("ul");
+  }
+
+  template() {
+    const { videos } = this.state;
+    return `
+    ${videos
+      .map(
+        ({ width, height }) => `<li>
+      <video autoplay playsinline width="${width}" height="${height}" />
+    </li>`
+      )
+      .join("")}
+    `;
+  }
+
+  render() {
+    const { videos } = this.state;
+    this.node.innerHTML = this.template();
+    const $videos = this.node.querySelectorAll("video");
+    $videos.forEach(($video, index) => {
+      $video.srcObject = videos[index].srcObject;
+    });
+  }
+}
+
+export default VideoList;

--- a/src/public/js/components/WebCam/WebCamVideo.js
+++ b/src/public/js/components/WebCam/WebCamVideo.js
@@ -9,7 +9,7 @@ class WebCamVideo extends Video {
       initialState: {
         autoplay: true,
         playsInline: true,
-        muted: false,
+        muted: true,
         ...defaultState,
         ...initialState,
       },

--- a/src/public/js/util/validator/isMobile.js
+++ b/src/public/js/util/validator/isMobile.js
@@ -1,0 +1,13 @@
+const isMobile = () => {
+  const userAgent = navigator.userAgent || navigator.vendor || window.opera;
+  return (
+    /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(
+      userAgent
+    ) ||
+    /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
+      userAgent.substr(0, 4)
+    )
+  );
+};
+
+export default isMobile;

--- a/src/public/js/webRTC.js
+++ b/src/public/js/webRTC.js
@@ -1,0 +1,19 @@
+const makeRTCPeerConnection = (tracks) => {
+  const peerConnection = new RTCPeerConnection({
+    iceServers: [
+      {
+        urls: [
+          "stun:stun.l.google.com:19302",
+          "stun:stun1.l.google.com:19302",
+          "stun:stun2.l.google.com:19302",
+          "stun:stun3.l.google.com:19302",
+          "stun:stun4.l.google.com:19302",
+        ],
+      },
+    ],
+  });
+
+  return peerConnection;
+};
+
+export default { makeRTCPeerConnection };

--- a/src/server.js
+++ b/src/server.js
@@ -74,6 +74,18 @@ io.on("connection", (socket) => {
     socket.to(room).emit("new_chat", { nickname: socket["__nickname"], chat });
     done?.();
   });
+
+  socket.on("offer", ({ offer, room }) => {
+    socket.to(room).emit("offer", { offer });
+  });
+
+  socket.on("answer", ({ answer, room }) => {
+    socket.to(room).emit("answer", { answer });
+  });
+
+  socket.on("ice", ({ candidate, room }) => {
+    socket.to(room).emit("ice", { candidate });
+  });
 });
 
 server.listen(3000, handleListen);


### PR DESCRIPTION
WebRTC 와 WebSocket을 이용하여 화상채팅 기능을 구현하였습니다.

WebSocket server는 WebRTC의 Signaling Server로서 이용되어집니다.

WebRTC를 구현하기 위해 RTCPeerConnection 객체를 이용하여 WebRTC API를 이용합니다.

### WebRTC 연결 수립 순서
연결 수립 클라이언트 A, B
1. Both :  RTCPeerConnection 객체를 생성.
2. Both : RTCPeerConnection.addTrack 메서드를 이용하여 공유할 트랙을 담아둔다.
3. A Client : RTCPeerConnection.createOffer() 를 이용하여 offer 생성 ( 초대장으로 비유 ) ( 비동기 )
4. A Client : 해당 offer를 RTCPeerConnection.setLocalDescription(offer)을 통해 할당.
5. A Client : offer 를 B Client 로 전달
6. B Client : 전달받은 offer를 RTCPeerConnection.setRemoteDescription(offer) 로 할당.
7. B Client : RTCPeerConnection.createAnswer() 를 통해 answer 생성
8. B Client : 해당 answer를 RTCPeerConnection.setLocalDescription(answer)
9. B Client : 해당 answer를 A Client에 전달.
10. A Client : 받은 answer를 setRemoteDescription(answer)
11. Both : icecandidate 이벤트가 발생.
12. Both : 생성된 ice의 candidate 프로퍼티를 상대에게 전달.
13. Both : 받은 Client는 RTCPeerConnection.addICECandidate(candidate) 를 통해 ice 추가.

연결 수립이 완료되면, 자동적으로 추가한 track이 전송되고, 각 클라이언트는 track 이벤트를 통해 해당 데이터를 전달 받는다.


### 연결 중 Track 이 변경될 경우
peerConnection.addTrack() 을 할경우, RTCSender 객체가 생성됩니다. 
peerConnection.getSenders() 를 통해 생성된 Sender 객체를 반환.
Sender.replaceTrack(newTrack) 을 통해 기존에 담긴 track을 교체 가능.